### PR TITLE
fix(api): allow resource cover uploads

### DIFF
--- a/apps/academy/src/components/image-input.tsx
+++ b/apps/academy/src/components/image-input.tsx
@@ -1,3 +1,4 @@
+import { MAX_COVER_IMAGE_BYTES } from '@blms/constants';
 import { Button, cn, customToast, FieldLabel } from '@blms/ui';
 import { useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -25,8 +26,6 @@ export const ImageInput = ({
   const inputRef = useRef<HTMLInputElement>(null);
 
   const handleImage = (file: File) => {
-    const MAX_SIZE = 15 * 1024 * 1024; // 15MB
-
     if (!file.type.startsWith('image/')) {
       customToast(t('educatorContent.onlyImages'), {
         mode: 'light',
@@ -37,7 +36,7 @@ export const ImageInput = ({
       return;
     }
 
-    if (file.size > MAX_SIZE) {
+    if (file.size > MAX_COVER_IMAGE_BYTES) {
       customToast(t('educatorContent.imageTooLarge'), {
         mode: 'light',
         color: 'warning',

--- a/apps/academy/src/routes/$lang/resources/-components/add-resource-modal.tsx
+++ b/apps/academy/src/routes/$lang/resources/-components/add-resource-modal.tsx
@@ -200,11 +200,16 @@ export const AddResourceModal = ({
         setCoverImageBase64(null);
         setCoverImageName(null);
       },
-      onError: () => {
-        customToast(t('resources.addResource.errorSendingAddition'), {
-          mode: 'light',
-          color: 'warning',
-        });
+      onError: (error: { data?: { httpStatus?: number } }) => {
+        customToast(
+          error.data?.httpStatus === 413
+            ? t('educatorContent.imageTooLarge')
+            : t('resources.addResource.errorSendingAddition'),
+          {
+            mode: 'light',
+            color: 'warning',
+          },
+        );
       },
     }),
   );

--- a/apps/academy/src/routes/$lang/resources/-components/add-resource-modal.tsx
+++ b/apps/academy/src/routes/$lang/resources/-components/add-resource-modal.tsx
@@ -1,3 +1,4 @@
+import type { AppRouter } from '@blms/api/src/trpc/types.ts';
 import type { ResourceType } from '@blms/constants';
 import {
   BasicModal,
@@ -18,6 +19,7 @@ import {
 } from '@blms/ui';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useMutation } from '@tanstack/react-query';
+import type { TRPCClientErrorLike } from '@trpc/client';
 import { useState } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
@@ -200,7 +202,7 @@ export const AddResourceModal = ({
         setCoverImageBase64(null);
         setCoverImageName(null);
       },
-      onError: (error: { data?: { httpStatus?: number } }) => {
+      onError: (error: TRPCClientErrorLike<AppRouter>) => {
         customToast(
           error.data?.httpStatus === 413
             ? t('educatorContent.imageTooLarge')

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,7 +1,7 @@
 import type { Server } from 'node:http';
 
 import { createExpressMiddleware } from '@trpc/server/adapters/express';
-import express, { json, Router } from 'express';
+import express, { type ErrorRequestHandler, json, Router } from 'express';
 import { requestLogging } from './config.js';
 import type { Dependencies } from './dependencies.js';
 import { createCookieSessionMiddleware } from './middlewares/session.js';
@@ -42,6 +42,33 @@ export const startServer = async (dependencies: Dependencies, port = 3000) => {
   app.use(createCookieSessionMiddleware(dependencies));
 
   const genRequestId = () => crypto.randomUUID().replace(/-/g, '').slice(0, 16);
+
+  const handlePayloadTooLarge: ErrorRequestHandler = (
+    error,
+    req,
+    res,
+    next,
+  ) => {
+    if (error.type !== 'entity.too.large') {
+      next(error);
+      return;
+    }
+
+    req.id ||= req.header('x-request-id') || genRequestId();
+    console.warn(
+      `[request] ${req.id} BODY_TOO_LARGE ${req.method} ${req.path} content_length=${req.header('content-length') ?? 'unknown'}`,
+    );
+    res.status(413).json({
+      error: {
+        json: {
+          message:
+            'The cover image is too large. Use an image smaller than 15 MB.',
+          code: -32600,
+          data: { code: 'PAYLOAD_TOO_LARGE', httpStatus: 413 },
+        },
+      },
+    });
+  };
 
   // Basic request logger + Set request ID
   app.use((req, res, next) => {
@@ -97,6 +124,7 @@ export const startServer = async (dependencies: Dependencies, port = 3000) => {
   const baseRoute = '/api';
   app.use(baseRoute, router);
   app.use(baseRoute, restRouter);
+  app.use(handlePayloadTooLarge);
 
   const server = app.listen(port, '0.0.0.0');
 

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,5 +1,6 @@
 import type { Server } from 'node:http';
 
+import { MAX_RESOURCE_SUBMISSION_BYTES } from '@blms/constants';
 import { createExpressMiddleware } from '@trpc/server/adapters/express';
 import express, { type ErrorRequestHandler, json, Router } from 'express';
 import { requestLogging } from './config.js';
@@ -23,8 +24,20 @@ export const startServer = async (dependencies: Dependencies, port = 3000) => {
   // Trust IP information from proxy (e.g. when behind Cloudflare)
   app.set('trust proxy', true);
 
-  // Resource submissions include a base64-encoded cover image.
-  app.use('/api/trpc/github.createResourcePR', json({ limit: '21mb' }));
+  // Resource submissions carry a base64-encoded cover image. tRPC batches
+  // procedures into a single comma-separated path, so match the procedure
+  // rather than an URL prefix.
+  const resourceSubmissionParser = json({
+    limit: MAX_RESOURCE_SUBMISSION_BYTES,
+  });
+
+  app.use('/api/trpc', (req, res, next) => {
+    const procedures = req.path.replace(/^\//, '').split(',');
+
+    return procedures.includes('github.createResourcePR')
+      ? resourceSubmissionParser(req, res, next)
+      : next();
+  });
 
   // Parse JSON bodies
   app.use(
@@ -61,8 +74,7 @@ export const startServer = async (dependencies: Dependencies, port = 3000) => {
     res.status(413).json({
       error: {
         json: {
-          message:
-            'The cover image is too large. Use an image smaller than 15 MB.',
+          message: 'Request body too large.',
           code: -32600,
           data: { code: 'PAYLOAD_TOO_LARGE', httpStatus: 413 },
         },

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -23,6 +23,9 @@ export const startServer = async (dependencies: Dependencies, port = 3000) => {
   // Trust IP information from proxy (e.g. when behind Cloudflare)
   app.set('trust proxy', true);
 
+  // Resource submissions include a base64-encoded cover image.
+  app.use('/api/trpc/github.createResourcePR', json({ limit: '21mb' }));
+
   // Parse JSON bodies
   app.use(
     json({

--- a/packages/constants/src/resources.ts
+++ b/packages/constants/src/resources.ts
@@ -52,3 +52,13 @@ export enum ResourceType {
   Glossary = 'glossary',
   Conference = 'conferences',
 }
+
+/** Largest cover image a contributor can submit, before base64 encoding. */
+export const MAX_COVER_IMAGE_BYTES = 15 * 1024 * 1024;
+
+/** Size of that image once base64 encoded, which is how it travels in JSON. */
+export const MAX_COVER_IMAGE_BASE64_BYTES = (MAX_COVER_IMAGE_BYTES / 3) * 4;
+
+/** Base64 cover plus room for the rest of the submission body. */
+export const MAX_RESOURCE_SUBMISSION_BYTES =
+  MAX_COVER_IMAGE_BASE64_BYTES + 1024 * 1024;

--- a/packages/schemas/src/content/resource.ts
+++ b/packages/schemas/src/content/resource.ts
@@ -1,3 +1,4 @@
+import { MAX_COVER_IMAGE_BASE64_BYTES } from '@blms/constants';
 import {
   contentResources,
   contentResourceTags,
@@ -40,7 +41,7 @@ export const createResourcePRSchema = z.object({
   coverImage: z
     .object({
       name: z.string(),
-      data: z.string(), // base64
+      data: z.string().max(MAX_COVER_IMAGE_BASE64_BYTES), // base64
     })
     .optional(),
   duration: z.number().optional(),


### PR DESCRIPTION
## Summary
- parse `github.createResourcePR` requests with a 21 MiB JSON limit
- keep the default JSON limit for every other API route
- accept the existing 15 MiB client-side cover-image limit after base64 encoding
- return a structured `PAYLOAD_TOO_LARGE` tRPC response and log only the request metadata when a parser rejects an oversized request
- show the existing localized image-size guidance when the API rejects an oversized cover

## Verification
- `pnpm exec biome check apps/api/src/server.ts`
- `pnpm turbo build --filter=@blms/academy...` — 17 packages, including API and Academy, completed successfully
- local BLMS API: a 120,283-byte book-submission request now reaches tRPC and returns the expected `401 UNAUTHORIZED` without a session, rather than `413 Payload Too Large`
- local tRPC client: an oversized cover receives `PAYLOAD_TOO_LARGE` / HTTP `413`; the modal maps that status to `educatorContent.imageTooLarge`

## Test coverage
The API has no HTTP integration-test harness. A local end-to-end route reproduction was run before and after the change; adding a test that only duplicated Express parser configuration would not cover the application route.

## Updated after review

Three commits amend the above — see [the review follow-up comment](https://github.com/PlanB-Network/bitcoin-learning-management-system/pull/1998#issuecomment-5327383923) for the evidence.

- the 21 MiB parser is now selected by matching the tRPC procedure, not by an URL prefix. Prefix matching missed comma-joined batch paths and leaked the raised limit to lookalike names such as `github.createResourcePRX`
- the 413 body carries a generic `Request body too large.`; the handler is global, so cover-image wording was wrong on every other route. The academy still maps on `httpStatus === 413` and shows `educatorContent.imageTooLarge`
- `coverImage.data` is capped in `createResourcePRSchema`. The 15 MiB limit previously existed only in the browser
- the raw limit and its base64 derivation live in `@blms/constants`, replacing three copies of the same figure

Files: 5 instead of 2. Known gap left for a separate issue — `image-input.tsx` checks `file.size` but transmits a WebP re-encode, so the 4/3 derivation is a heuristic rather than a bound.
