### PR TITLE
fix(sync): report which professor failed to delete and why

### DIFF
--- a/packages/service-content/src/lib/professors/import/index.ts
+++ b/packages/service-content/src/lib/professors/import/index.ts
@@ -128,17 +128,38 @@ export const createUpdateProfessors = ({
   };
 };
 
+const formatError = (error: unknown) => {
+  const detail = (error as { detail?: string }).detail;
+  return `${error}${detail ? ` - Detail: ${detail}` : ''}`;
+};
+
 export const createDeleteProfessors = ({
   postgres,
 }: Pick<Dependencies, 'postgres'>) => {
   return async (sync_date: number, errors: string[]) => {
+    let stale: Array<{ id: string; name: string }>;
+
     try {
-      await postgres.exec(
-        sql`DELETE FROM content.professors WHERE last_sync < ${sync_date}
-      `,
+      stale = await postgres.exec<{ id: string; name: string }>(
+        sql`SELECT id, name FROM content.professors WHERE last_sync < ${sync_date}`,
       );
-    } catch {
-      errors.push('Error deleting professors');
+    } catch (error) {
+      errors.push(`Error listing professors to delete: ${formatError(error)}`);
+      return;
+    }
+
+    // Delete one by one: a professor still referenced by a user account or by
+    // another table must not prevent the other stale profiles from being removed.
+    for (const professor of stale) {
+      try {
+        await postgres.exec(
+          sql`DELETE FROM content.professors WHERE id = ${professor.id}`,
+        );
+      } catch (error) {
+        errors.push(
+          `Error deleting professor ${professor.name} (${professor.id}): ${formatError(error)}`,
+        );
+      }
     }
   };
 };


### PR DESCRIPTION
## Problem

When a professor profile is removed from the content repos, the importer deletes its row at the end of the sync. If any row still references that professor, the delete is refused and the sync reports:

```json
{"success":false,"syncErrors":["Error deleting professors"]}
```

That message is unactionable. `createDeleteProfessors` caught with a bare `catch {}`, discarding the Postgres error, the constraint name and the detail. It names no professor, no table and no constraint — so pinning down a real occurrence meant enumerating every foreign key into `content.professors` by hand and grepping every content repo for the id.

There is a second problem: the delete ran as one statement covering all stale professors. A single blocked profile aborts the batch, so every other stale profile silently survives with it.

## Fix

Select the stale professors first, then delete them one at a time. One blocked profile no longer prevents the others from being removed, and each failure is reported with the professor's name, its id, and the Postgres detail:

```
Error deleting professor Ajelex (e320ccda-…): PostgresError: update or delete on table "professors"
violates foreign key constraint "accounts_professor_id_professors_id_fk" on table "accounts"
- Detail: Key (id)=(e320ccda-…) is still referenced from table "accounts".
```

The `- Detail:` formatting matches what the courses importer already does for its own errors.

## Deliberately not fixed here

The importer does not unlink the blocking rows. Five foreign keys into `content.professors` are `ON DELETE no action`, and one is `users.accounts.professor_id` — which can point at a real user account holding the `professor` role. Nulling that during a content sync would strip a person's teacher permissions as a side effect of a content edit, and leave `role = 'professor'` dangling with no linked profile. That conflict should surface to a human, which is what this change does.

## Verification

`tsc --noEmit` and `biome check` both clean on the changed package.

Behaviour checked against a live production case: exactly one row blocks the delete of the Ajelex profile, and it is in `users.accounts`. With this change the sync would have named the professor and the constraint on the first run instead of requiring a manual hunt.