### PR TITLE
fix(academy): handle no active live classes

### DIFF
--- a/apps/academy/package.json
+++ b/apps/academy/package.json
@@ -99,6 +99,7 @@
     "pear:stage": "pear stage dev ./dist",
     "pear:release": "pear release dev ./dist",
     "pear:seed": "pear seed dev ./dist",
+    "test": "mocha src/**/*.test.ts",
     "lint": "biome check .",
     "trace-performance": "npx tsc --extendedDiagnostics --noEmit -p tsconfig.app.json | head -n 12 > performance.log",
     "type-check": "tsc --build"

--- a/apps/academy/src/routes/$lang/_course/live-classes/-utils.test.ts
+++ b/apps/academy/src/routes/$lang/_course/live-classes/-utils.test.ts
@@ -1,0 +1,47 @@
+/// <reference types="mocha" />
+
+import assert from 'node:assert';
+import { findActivePlanbSchoolCourse } from './-utils.ts';
+
+const now = new Date('2026-09-09T00:00:00.000Z');
+
+describe('findActivePlanbSchoolCourse', () => {
+  it('returns undefined when every Plan B School course has ended', () => {
+    assert.equal(
+      findActivePlanbSchoolCourse(
+        [
+          {
+            endDate: new Date('2026-07-31T00:00:00.000Z'),
+            isArchived: false,
+            isPlanbSchool: true,
+          },
+        ],
+        now,
+      ),
+      undefined,
+    );
+  });
+
+  it('returns the current Plan B School course', () => {
+    const course = {
+      endDate: new Date('2026-12-31T00:00:00.000Z'),
+      isArchived: false,
+      isPlanbSchool: true,
+    };
+
+    assert.equal(
+      findActivePlanbSchoolCourse(
+        [
+          {
+            endDate: new Date('2026-07-31T00:00:00.000Z'),
+            isArchived: false,
+            isPlanbSchool: true,
+          },
+          course,
+        ],
+        now,
+      ),
+      course,
+    );
+  });
+});

--- a/apps/academy/src/routes/$lang/_course/live-classes/-utils.ts
+++ b/apps/academy/src/routes/$lang/_course/live-classes/-utils.ts
@@ -1,0 +1,17 @@
+import type { JoinedCourse } from '@blms/types';
+
+type PlanbSchoolCourse = Pick<
+  JoinedCourse,
+  'endDate' | 'isArchived' | 'isPlanbSchool'
+>;
+
+export const findActivePlanbSchoolCourse = <Course extends PlanbSchoolCourse>(
+  courses: Course[],
+  now = new Date(),
+) =>
+  courses.find(
+    (course) =>
+      course.isArchived === false &&
+      course.isPlanbSchool === true &&
+      (!course.endDate || course.endDate.getTime() > now.getTime()),
+  );

--- a/apps/academy/src/routes/$lang/_course/live-classes/index.tsx
+++ b/apps/academy/src/routes/$lang/_course/live-classes/index.tsx
@@ -21,6 +21,7 @@ import { formatShortDateRange } from '#src/utils/date.ts';
 import { resourceImgUrl } from '#src/utils/index.ts';
 import { getSystemLanguage, isLanguageMatch } from '#src/utils/language.ts';
 import { trpc } from '#src/utils/trpc.ts';
+import { findActivePlanbSchoolCourse } from './-utils.ts';
 
 export const Route = createFileRoute('/$lang/_course/live-classes/')({
   component: AllCourses,
@@ -59,14 +60,7 @@ function AllCourses() {
           return 0;
         });
 
-  const planbCourses = !courses
-    ? []
-    : courses.filter(
-        (course) =>
-          course.isArchived === false &&
-          course.isPlanbSchool === true &&
-          (course.endDate ? course.endDate.getTime() > Date.now() : true),
-      );
+  const planbCourse = findActivePlanbSchoolCourse(courses ?? []);
 
   const systemLanguage = useMemo(() => getSystemLanguage(), []);
 
@@ -158,20 +152,22 @@ function AllCourses() {
         {t('courses.liveClasses.title')}
       </h2>
 
-      <div className="bg-vertical-orange-gradient border border-orange-200 rounded-2xl">
-        <div className="max-lg:hidden flex flex-col">
-          <div className=" py-6 px-6 w-full">
-            <h2 className="display-base">{t('courses.liveClasses.title')}</h2>
+      {planbCourse && (
+        <div className="bg-vertical-orange-gradient border border-orange-200 rounded-2xl">
+          <div className="max-lg:hidden flex flex-col">
+            <div className=" py-6 px-6 w-full">
+              <h2 className="display-base">{t('courses.liveClasses.title')}</h2>
+            </div>
+            <Link to={'/programs'} />
           </div>
-          <Link to={'/programs'} />
-        </div>
 
-        <div className="flex flex-wrap gap-4 lg:gap-8 mt-2 lg:mt-4 px-2 lg:px-6 pb-2 lg:pb-6">
-          <div className="w-full">
-            <ProgramCard course={planbCourses.at(0)!} />
+          <div className="flex flex-wrap gap-4 lg:gap-8 mt-2 lg:mt-4 px-2 lg:px-6 pb-2 lg:pb-6">
+            <div className="w-full">
+              <ProgramCard course={planbCourse} />
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
       {otherCourses.length === 0 ? null : (
         <>


### PR DESCRIPTION
## What changed

- select the current Plan B School course through a typed helper
- render the highlighted program card only when an active course exists
- add Academy regression tests for an expired-only course list

## Why

When every Plan B School course had ended, the live-classes route passed an undefined value to ProgramCard. Rendering then crashed while reading startDate and the prerender service cached the error page.

Expired and replay courses keep their existing classification; this change only prevents the live-classes page from crashing when there is no active cohort.

## Verification

- pnpm --filter @blms/academy test
- pnpm --filter @blms/academy check-types
- pnpm --filter @blms/academy build
- Biome check on all changed files
