### PR TITLE
fix(academy): replace broken teacher booking CTA

### DIFF
--- a/apps/academy/package.json
+++ b/apps/academy/package.json
@@ -3,7 +3,6 @@
     "@blms/constants": "workspace:*",
     "@blms/shared": "workspace:*",
     "@blms/ui": "workspace:*",
-    "@calcom/embed-react": "^1.5.3",
     "@hookform/resolvers": "^5.2.2",
     "@react-hooks-library/core": "^0.6.2",
     "@stripe/react-stripe-js": "^5.6.0",

--- a/apps/academy/public/locales/en.json
+++ b/apps/academy/public/locales/en.json
@@ -125,13 +125,14 @@
   "becomeTeacher": {
     "activeBitcoinLearners": "Active Bitcoin learners",
     "bitcoinOnly": "Bitcoin-only",
-    "bookCall": "Book a 30-min call to become a teacher",
-    "description": "If you’re a passionate Bitcoiner who loves teaching and wants to make a real impact in your local community, you can host your own course on our learning platform.",
+    "description": "If you’re a passionate Bitcoiner who loves teaching, you can propose your own Bitcoin course through our open-source GitHub repository.",
     "enhanceExperience": "<0>Enhance your students’ learning experience</0> with the platform tools",
     "globalReach": "Global reach",
-    "hostOwnCourse": "<0>Host your own course</0>, online or in-person",
+    "hostOwnCourse": "<0>Publish your own self-paced course</0> on Plan ₿ Academy",
     "inspireLearners": "Inspire a community of learners",
     "joinMission": "<0>Join the mission</0> as a true Bitcoin educator",
+    "liveClassProposalsPaused": "We are not accepting proposals for live classes at the moment.",
+    "proposeCourse": "Learn how to propose your course on GitHub",
     "superiorAmount": ">{{amount}}",
     "teachWhatYouLove": "<0>Teach what you love</0>",
     "title": "Teach Bitcoin and inspire others"

--- a/apps/academy/src/routes/$lang/_misc/become-teacher.tsx
+++ b/apps/academy/src/routes/$lang/_misc/become-teacher.tsx
@@ -1,7 +1,5 @@
 import { Button } from '@blms/ui';
-import { getCalApi } from '@calcom/embed-react';
-import { createFileRoute } from '@tanstack/react-router';
-import { useEffect } from 'react';
+import { createFileRoute, Link } from '@tanstack/react-router';
 import { Trans, useTranslation } from 'react-i18next';
 import type { IconType } from 'react-icons/lib';
 import {
@@ -65,7 +63,12 @@ function BecomeTeacher() {
           subtitle={t('becomeTeacher.globalReach')}
         />
       </div>
-      <CalComButton />
+      <div className="flex flex-col items-center gap-4 mt-10 md:mt-14">
+        <p className="body-base text-center text-neutral-700">
+          {t('becomeTeacher.liveClassProposalsPaused')}
+        </p>
+        <CourseProposalButton />
+      </div>
     </PageLayout>
   );
 }
@@ -106,37 +109,19 @@ const InfoBox = ({ icon, title, subtitle }: InfoBoxProps) => {
   );
 };
 
-const CalComButton = () => {
+const CourseProposalButton = () => {
   const { t } = useTranslation();
   const isMobile = useSmaller('md') || window.innerWidth < 768;
 
-  useEffect(() => {
-    (async () => {
-      const cal = await getCalApi({
-        namespace: 'become-a-teacher',
-        embedJsUrl: 'https://cal.planb.network/embed/embed.js',
-      });
-      cal('ui', {
-        theme: 'light',
-        cssVarsPerTheme: {
-          light: { 'cal-brand': '#ff5e00' },
-          dark: { 'cal-brand': '#F7931A' },
-        },
-        hideEventTypeDetails: false,
-        layout: 'month_view',
-      });
-    })();
-  }, []);
   return (
     <Button
-      data-cal-namespace="become-a-teacher"
-      data-cal-link="asi0/become-a-teacher"
-      data-cal-origin="https://cal.planb.network"
-      data-cal-config='{"layout":"month_view","theme":"light"}'
+      asChild
       size={isMobile ? 'm' : 'l'}
-      className="mt-10 md:mt-14 mx-auto text-wrap! max-w-full"
+      className="text-wrap! max-w-full"
     >
-      {t('becomeTeacher.bookCall')}
+      <Link to="/tutorials/contribution/content/contribution-tutorials-4d142a6a-9127-4ffb-9e0a-5aba29f169e2">
+        {t('becomeTeacher.proposeCourse')}
+      </Link>
     </Button>
   );
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,9 +53,6 @@ importers:
       '@blms/ui':
         specifier: workspace:*
         version: link:../../packages/ui
-      '@calcom/embed-react':
-        specifier: ^1.5.3
-        version: 1.5.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       '@hookform/resolvers':
         specifier: ^5.2.2
         version: 5.2.2(react-hook-form@7.71.1(react@19.2.4))
@@ -1371,18 +1368,6 @@ packages:
 
   '@bufbuild/protobuf@2.11.0':
     resolution: {integrity: sha512-sBXGT13cpmPR5BMgHE6UEEfEaShh5Ror6rfN3yEK5si7QVrtZg8LEPQb0VVhiLRUslD2yLnXtnRzG035J/mZXQ==}
-
-  '@calcom/embed-core@1.5.3':
-    resolution: {integrity: sha512-GeId9gaByJ5EWiPmuvelZOvFWPOTWkcWZr5vGTCbIUTX125oE5yn0n8lDF1MJk5Xj1WO+/dk9jKIE08Ad9ytiQ==}
-
-  '@calcom/embed-react@1.5.3':
-    resolution: {integrity: sha512-JCgge04pc8fhdvUmPNVLhW8/lCWK+AAziKecKWWPfv1nn2s+qKP2BwsEAnxhxK9yPOBgE1EIEgmYkrrNB1iajA==}
-    peerDependencies:
-      react: ^18.2.0 || ^19.0.0
-      react-dom: ^18.2.0 || ^19.0.0
-
-  '@calcom/embed-snippet@1.3.3':
-    resolution: {integrity: sha512-pqqKaeLB8R6BvyegcpI9gAyY6Xyx1bKYfWvIGOvIbTpguWyM1BBBVcT9DCeGe8Zw7Ujp5K56ci7isRUrT2Uadg==}
 
   '@cropper/element-canvas@2.1.0':
     resolution: {integrity: sha512-el+rfJpZxsD2q5XxDBA4fRczcrOqB65Lb7roqXOq8LKufwf4bPWA9C6DjNJJahh/TP94dsLIEy3tSkgRMDv3Aw==}
@@ -8920,19 +8905,6 @@ snapshots:
     optional: true
 
   '@bufbuild/protobuf@2.11.0': {}
-
-  '@calcom/embed-core@1.5.3': {}
-
-  '@calcom/embed-react@1.5.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)':
-    dependencies:
-      '@calcom/embed-core': 1.5.3
-      '@calcom/embed-snippet': 1.3.3
-      react: 19.2.4
-      react-dom: 19.2.4(react@19.2.4)
-
-  '@calcom/embed-snippet@1.3.3':
-    dependencies:
-      '@calcom/embed-core': 1.5.3
 
   '@cropper/element-canvas@2.1.0':
     dependencies:


### PR DESCRIPTION
## Summary

- replace the broken Cal booking CTA on the Become a Teacher page with a link to the course-contribution tutorial
- explain that course proposals are made through GitHub and that live-class proposals are currently paused
- remove the unused Cal embed dependency

## Verification

- `pnpm exec biome check apps/academy/src/routes/$lang/_misc/become-teacher.tsx apps/academy/public/locales/en.json apps/academy/package.json pnpm-lock.yaml`
- `pnpm --filter @blms/academy check-types`
- verified the linked tutorial returns HTTP 200