### PR TITLE
fix(academy): show empty live classes state

### DIFF
--- a/apps/academy/public/locales/en.json
+++ b/apps/academy/public/locales/en.json
@@ -335,6 +335,11 @@
     },
     "liveClasses": {
       "allOtherTitle": "All other live classes",
+      "emptyState": {
+        "action": "Explore self-paced courses",
+        "description": "New teacher-led courses will appear here when dates are confirmed.",
+        "title": "No live classes scheduled"
+      },
       "liveClasses": "Live classes",
       "program": {
         "goal": "Master the Bitcoin industry with Giacomo Zucco in a 5-month program that blends theory, real-case studies, and exclusive networking opportunities.",

--- a/apps/academy/src/routes/$lang/_course/live-classes/index.tsx
+++ b/apps/academy/src/routes/$lang/_course/live-classes/index.tsx
@@ -1,13 +1,14 @@
 import { TeachingFormat } from '@blms/constants';
 import { getCountryForFlagFromAddress } from '@blms/shared';
 import type { CourseResponse, JoinedCourse } from '@blms/types';
-import { Button, cn, Flag, Image, Loader } from '@blms/ui';
+import { Button, cn, EmptyState, Flag, Image, Loader } from '@blms/ui';
 import { useQuery } from '@tanstack/react-query';
 import { createFileRoute, Link } from '@tanstack/react-router';
 import { useContext, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
   TbCalendarEvent,
+  TbCalendarOff,
   TbChevronDown,
   TbChevronRight,
   TbClock,
@@ -167,6 +168,19 @@ function AllCourses() {
             </div>
           </div>
         </div>
+      )}
+
+      {!planbCourse && otherCourses.length === 0 && (
+        <EmptyState
+          title={t('courses.liveClasses.emptyState.title')}
+          description={t('courses.liveClasses.emptyState.description')}
+          icon={TbCalendarOff}
+          linkButton={{
+            href: '/learn-anytime',
+            label: t('courses.liveClasses.emptyState.action'),
+          }}
+          className="mt-6 lg:mt-8"
+        />
       )}
 
       {otherCourses.length === 0 ? null : (

--- a/apps/academy/src/routes/$lang/_course/live-classes/index.tsx
+++ b/apps/academy/src/routes/$lang/_course/live-classes/index.tsx
@@ -149,10 +149,6 @@ function AllCourses() {
         </div>
       )}
 
-      <h2 className="lg:hidden title-large-sb-24px font-semibold mb-2 lg:mb-6">
-        {t('courses.liveClasses.title')}
-      </h2>
-
       {planbCourse && (
         <div className="bg-vertical-orange-gradient border border-orange-200 rounded-2xl">
           <div className="max-lg:hidden flex flex-col">


### PR DESCRIPTION
## Summary

- show the shared `EmptyState` when no featured program or other live class is available
- explain that new teacher-led courses appear once dates are confirmed
- direct visitors to the existing self-paced course catalog
- remove the mobile-only “Lead the Change. Master Bitcoin.” caption

The empty state is deliberately not shown when any live course is available, so existing course cards and in-progress courses keep their current behavior.

## Verification

- `pnpm --filter @blms/academy test` (2 passing)
- Biome check on both changed files
- rendered the real `/en/live-classes` route against production course data at mobile and laptop widths

### Mobile, 390 × 844

![Live classes empty state on mobile](https://static.crqpt.com/reports/live-classes-empty-state-pr/live-classes-empty-state-mobile-no-caption.png)

### Laptop, 1440 × 1000

![Live classes empty state on laptop](https://static.crqpt.com/reports/live-classes-empty-state-pr/live-classes-empty-state-laptop-no-caption.png)
